### PR TITLE
fix(rest): remove request Content-Length setter

### DIFF
--- a/.changeset/chatty-parrots-mate.md
+++ b/.changeset/chatty-parrots-mate.md
@@ -1,5 +1,5 @@
 ---
-'@purplet/rest': minor
+'@purplet/rest': patch
 ---
 
 Remove request Content-Length setter

--- a/.changeset/chatty-parrots-mate.md
+++ b/.changeset/chatty-parrots-mate.md
@@ -1,0 +1,5 @@
+---
+'@purplet/rest': minor
+---
+
+Remove request Content-Length setter

--- a/packages/rest/src/Rest.ts
+++ b/packages/rest/src/Rest.ts
@@ -124,7 +124,6 @@ export class Rest {
     } else if (body) {
       // JSON body is to be sent as application/json
       headers.set('Content-Type', 'application/json');
-      headers.set('Content-Length', body.length.toString());
     }
 
     if (options.reason?.length) {


### PR DESCRIPTION
Setting the Content-Length assume that you exactly know the data byteLength you are sending, in case of jsons some characters could have code point greater than 0x7F which mean the actual character take 2 to 4 bytes instead of only one.

Node already handle Content-Length internally based on body byteLength, then this fix remove the explicit Content-Length setter to use the internal one.