### PR TITLE
Rest: Support `NodeJS.ReadableStream` and `ReadableStream` in `files` array

### DIFF
--- a/.changeset/rotten-nails-allow.md
+++ b/.changeset/rotten-nails-allow.md
@@ -1,0 +1,5 @@
+---
+"@purplet/rest": minor
+---
+
+Support node.js readable streams in `files` array.

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1,5 +1,13 @@
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
-export type FileData = string | Uint8Array | Blob | ArrayBufferLike | ArrayBufferable | Streamable;
+export type FileData =
+  | string
+  | Uint8Array
+  | Blob
+  | ArrayBufferLike
+  | ArrayBufferable
+  | Streamable
+  | Buffer
+  | AsyncIterable<string | Uint8Array | Blob | ArrayBufferLike | Buffer>;
 export type TokenType = 'Bot' | 'Bearer';
 
 export interface ArrayBufferable {
@@ -9,6 +17,8 @@ export interface ArrayBufferable {
 export interface Streamable {
   stream(): ReadableStream<Uint8Array>;
 }
+
+export interface NodeReadableLike {}
 
 export interface RestOptions {
   /** Bot Token. */

--- a/packages/rest/src/utils.ts
+++ b/packages/rest/src/utils.ts
@@ -36,6 +36,12 @@ function isStreamable(data: FileData): data is Streamable {
   return typeof (data as Streamable).stream === 'function';
 }
 
+function isAsyncIterable(
+  data: FileData
+): data is AsyncIterable<string | Uint8Array | Blob | ArrayBufferLike | Buffer> {
+  return typeof (data as AsyncIterable<FileData>)[Symbol.asyncIterator] === 'function';
+}
+
 export async function toBlob(data: FileData): Promise<Blob> {
   if (data instanceof Blob) {
     return data;
@@ -54,6 +60,15 @@ export async function toBlob(data: FileData): Promise<Blob> {
     } while (!read.done);
 
     return new Blob([]);
+  }
+  if (isAsyncIterable(data)) {
+    const values = [];
+
+    for await (const value of data) {
+      values.push(value);
+    }
+
+    return new Blob(values);
   }
   return new Blob([data instanceof Uint8Array ? data.buffer : data]);
 }


### PR DESCRIPTION
This is done by implementing support for the async iterable aspect of a `Stream.Readable`.

Fixes #49