### PR TITLE
fix(rest): never resolving when status 204

### DIFF
--- a/.changeset/cyan-ads-cover.md
+++ b/.changeset/cyan-ads-cover.md
@@ -1,0 +1,5 @@
+---
+'@purplet/rest': patch
+---
+
+Fix request never resolving when status 204

--- a/packages/rest/src/Fetcher.ts
+++ b/packages/rest/src/Fetcher.ts
@@ -179,7 +179,7 @@ export class Fetcher {
     }
 
     if (response.ok) {
-      response.status === 204 ? entry.resolve() : entry.resolve(await response.json());
+      entry.resolve(response.status === 204 ? undefined : await response.json());
       return;
     }
 

--- a/packages/rest/src/Fetcher.ts
+++ b/packages/rest/src/Fetcher.ts
@@ -14,7 +14,7 @@ export interface QueueEntry {
   bucketId: string;
   endpointId: string;
   majorId: string;
-  resolve(data: any): void;
+  resolve(data?: any): void;
   reject(error: Error): void;
 }
 
@@ -179,7 +179,7 @@ export class Fetcher {
     }
 
     if (response.ok) {
-      response.status === 204 ? undefined : entry.resolve(await response.json());
+      response.status === 204 ? entry.resolve() : entry.resolve(await response.json());
       return;
     }
 


### PR DESCRIPTION
This fix the never resolving promise on the 204 status code response, that cause getting stuck on for example deferredMessage which you need to followup after.